### PR TITLE
chore(railway): install uv via installer and call absolute path in railpack.json

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -3,13 +3,13 @@
     "install": {
       "commands": [
         "python -m pip install --upgrade pip",
-        "python -m pip install uv",
-        "UV_NO_DEV=1 uv sync"
+        "curl -LsSf https://astral.sh/uv/install.sh | sh",
+        "UV_NO_DEV=1 $HOME/.local/bin/uv sync"
       ]
     }
   },
   "deploy": {
-    "startCommand": "uv run uvicorn aiblock_mcp.server:app --host 0.0.0.0 --port ${PORT:-8000}"
+    "startCommand": "$HOME/.local/bin/uv run uvicorn aiblock_mcp.server:app --host 0.0.0.0 --port ${PORT:-8000}"
   }
 }
 


### PR DESCRIPTION
- Install uv using official installer during Railway build
- Use absolute $HOME/.local/bin/uv for sync/run to avoid PATH issues
- Keeps runtime deps minimal and aligns with Plan 1/4 deployment guidance