### PR TITLE
chore(mcp): rename tool names to client-agnostic safe slugs

### DIFF
--- a/plans/2_define_server_scope_and_tools.md
+++ b/plans/2_define_server_scope_and_tools.md
@@ -30,71 +30,71 @@ Use the following as guidance for implementing MCP tools (function names are sug
 - Return outputs that mirror the AIBlock SDK payloads exactly (no field renaming or reshaping). Include all fields the SDK returns.
 - Log request ID and tool name for observability (added later).
 
-1) wallet.generate_seed_phrase
+1) generate-seed-phrase
 - Input: `{ entropyBits?: number }` (optional; default per SDK)
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `INTERNAL`
 - Notes: Do not log or persist seed phrase.
 
-2) wallet.generate_keypair
+2) generate-keypair
 - Input: `{ seedPhrase?: string }` (optional; if omitted, generate ephemeral one)
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `INTERNAL`
 - Notes: Only include `secretKey` in explicitly privileged contexts; by default, omit. Prefer returning an opaque `keyId` in future.
 
-3) wallet.get_balance
+3) get-balance
 - Input: `{}` (current wallet)
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `NOT_FOUND`, `UPSTREAM_UNAVAILABLE`
 - SDK mapping: `BlockchainClient.get_balance(address)`
 
-4) wallet.create_item_asset
+4) create-item-asset
 - Input: `{ keyId?: string, seedPhrase?: string, name: string, metadata?: object }`
 - Output: Mirror SDK structure exactly.
 - Errors: `UNAUTHENTICATED` (if missing signing material), `INVALID_ARGUMENT`, `UPSTREAM_UNAVAILABLE`, `FAILED_PRECONDITION`
 - Notes: Either use `seedPhrase` (dev) or a managed `keyId` (prod). Ensure idempotency keys if creating server-side.
 
-5) wallet.sign_transaction
+5) sign-transaction
 - Input: `{ keyId?: string, seedPhrase?: string, transaction: object }`
 - Output: Mirror SDK structure exactly.
 - Errors: `UNAUTHENTICATED`, `INVALID_ARGUMENT`, `INTERNAL`
 
-6) blockchain.get_latest_block
+6) blockchain-get-latest-block
 - Input: `{}`
 - Output: Mirror SDK structure exactly.
 - Errors: `UPSTREAM_UNAVAILABLE`, `INTERNAL`
 - SDK mapping: `BlockchainClient.get_latest_block()`
 
-7) blockchain.get_block_by_number
+7) blockchain-get-block-by-number
 - Input: `{ height: number }`
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `NOT_FOUND`, `UPSTREAM_UNAVAILABLE`
 - SDK mapping: `BlockchainClient.get_block_by_num(height)`
 
-8) blockchain.get_entry_by_hash
+8) blockchain-get-entry-by-hash
 - Input: `{ hash: string }`
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `NOT_FOUND`, `UPSTREAM_UNAVAILABLE`
 - SDK mapping: `BlockchainClient.get_blockchain_entry(hash)`
-11) blockchain.get_transaction_by_hash
+11) get-transaction-by-hash
 - Input: `{ tx_hash: string }`
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `NOT_FOUND`, `UPSTREAM_UNAVAILABLE`
 - SDK mapping: `BlockchainClient.get_transaction_by_hash(tx_hash)`
 
-12) blockchain.fetch_transactions
+12) fetch-transactions
 - Input: `{ tx_hashes: string[] }`
 - Output: Mirror SDK structure exactly.
 - Errors: `INVALID_ARGUMENT`, `UPSTREAM_UNAVAILABLE`
 - SDK mapping: `BlockchainClient.fetch_transactions(tx_hashes)`
 
-9) blockchain.get_total_supply
+9) get-total-supply
 - Input: `{}`
 - Output: Mirror SDK structure exactly.
 - Errors: `UPSTREAM_UNAVAILABLE`
 - SDK mapping: `BlockchainClient.get_total_supply()`
 
-10) blockchain.get_issued_supply
+10) get-issued-supply
 - Input: `{}`
 - Output: Mirror SDK structure exactly.
 - Errors: `UPSTREAM_UNAVAILABLE`

--- a/plans/5_run_and_test.md
+++ b/plans/5_run_and_test.md
@@ -34,11 +34,16 @@ References
 - **Action (guidance):**
   - Launch the official MCP Inspector.
   - Configure a connection to `http://localhost:8000/mcp` (Streamable HTTP).
-  - Confirm tool listing shows: `wallet.generate_seed_phrase`, `wallet.generate_keypair`, `wallet.get_balance`, `wallet.fetch_balance`, `blockchain.get_latest_block`, `blockchain.get_block_by_number`, `blockchain.get_entry_by_hash`, `blockchain.get_total_supply`, `blockchain.get_issued_supply`, `blockchain.get_transaction_by_hash`, `blockchain.fetch_transactions`, plus `health`, `version`.
+  - Confirm tool listing shows: `generate-seed-phrase`, `generate-keypair`, `get-balance`, `fetch-balance`, `get-latest-block`, `get-block-by-number`, `get-entry-by-hash`, `get-total-supply`, `get-issued-supply`, `get-transaction-by-hash`, `fetch-transactions`, plus `health`, `version`.
   - Confirm prompts listing includes registered prompt names (e.g., `prompt.block.explain_header`, `prompt.tx.explain`).
   - Fetch a prompt and verify it returns a list of one user message with rendered content.
   - Execute sample calls and verify responses and headers (e.g., `Mcp-Session-Id`).
   - For dev auth, set `MCP_DEV_AUTH_TOKEN` on server and provide `Authorization: Bearer <token>` in Inspector requests when testing privileged tools.
+
+Deployment sanity (Railway)
+- Build: logs show `uv sync` with pyproject/uv.lock detected by Railpack.
+- Start: command uses `/app/.venv/bin/uvicorn ... --port $PORT`. No `uv not found`.
+- Runtime: tools list, prompts list/get work via Inspector.
 
 ---
 

--- a/src/aiblock_mcp/server.py
+++ b/src/aiblock_mcp/server.py
@@ -37,7 +37,7 @@ def version() -> dict:
     return version_impl()
 
 
-@mcp.tool(name="blockchain.get_latest_block")
+@mcp.tool(name="get-latest-block")
 def blockchain_get_latest_block() -> dict:
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -45,21 +45,21 @@ def blockchain_get_latest_block() -> dict:
     return resp.model_dump()
 
 
-@mcp.tool(name="wallet.get_balance")
+@mcp.tool(name="get-balance")
 def wallet_get_balance() -> dict:
     print("[tool] wallet.get_balance invoked", flush=True)
     resp = wallet_balance()
     return resp.model_dump()
 
 
-@mcp.tool(name="wallet.fetch_balance")
+@mcp.tool(name="fetch-balance")
 def wallet_fetch_balance_tool(addresses: list[str]) -> dict:
     print(f"[tool] wallet.fetch_balance invoked with addresses={addresses}", flush=True)
     resp = wallet_fetch_balance(addresses)
     return resp.model_dump()
 
 
-@mcp.tool(name="blockchain.get_total_supply")
+@mcp.tool(name="get-total-supply")
 def blockchain_get_total_supply() -> dict:
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -67,7 +67,7 @@ def blockchain_get_total_supply() -> dict:
     return resp.model_dump()
 
 
-@mcp.tool(name="blockchain.get_issued_supply")
+@mcp.tool(name="get-issued-supply")
 def blockchain_get_issued_supply() -> dict:
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -75,7 +75,7 @@ def blockchain_get_issued_supply() -> dict:
     return resp.model_dump()
 
 
-@mcp.tool(name="blockchain.get_block_by_number")
+@mcp.tool(name="get-block-by-number")
 def blockchain_get_block_by_number(height: int) -> dict:
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -83,7 +83,7 @@ def blockchain_get_block_by_number(height: int) -> dict:
     return resp.model_dump()
 
 
-@mcp.tool(name="blockchain.get_entry_by_hash")
+@mcp.tool(name="get-entry-by-hash")
 def blockchain_get_entry_by_hash(hash: str) -> dict:  # noqa: A002
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -91,7 +91,7 @@ def blockchain_get_entry_by_hash(hash: str) -> dict:  # noqa: A002
     return resp.model_dump()
 
 
-@mcp.tool(name="blockchain.get_transaction_by_hash")
+@mcp.tool(name="get-transaction-by-hash")
 def blockchain_get_transaction_by_hash(tx_hash: str) -> dict:
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -99,7 +99,7 @@ def blockchain_get_transaction_by_hash(tx_hash: str) -> dict:
     return resp.model_dump()
 
 
-@mcp.tool(name="blockchain.fetch_transactions")
+@mcp.tool(name="fetch-transactions")
 def blockchain_fetch_transactions(tx_hashes: list[str]) -> dict:
     cfg = get_config()
     client = create_blockchain_client(cfg)
@@ -107,12 +107,12 @@ def blockchain_fetch_transactions(tx_hashes: list[str]) -> dict:
     return resp.model_dump()
 
 
-@mcp.tool(name="wallet.generate_seed_phrase")
+@mcp.tool(name="generate-seed-phrase")
 def wallet_generate_seed_phrase() -> dict:
     return gen_seed_impl()
 
 
-@mcp.tool(name="wallet.generate_keypair")
+@mcp.tool(name="generate-keypair")
 def wallet_generate_keypair(seedPhrase: Optional[str] = None) -> dict:  # noqa: N803 (external name)
     return gen_keypair_impl(seed_phrase=seedPhrase)
 


### PR DESCRIPTION
- Renamed MCP tool names to simple, unique, client-agnostic slugs (lowercase with hyphens)
- Updated Plan 2 and Plan 5 accordingly
- No functional changes to tool behavior or schemas

Rationale: keep names stable and decoupled from SDK clients; descriptions carry human-friendly context.